### PR TITLE
remove getFileExtension in loader.mjs

### DIFF
--- a/upm/Runtime/Resources/puer-commonjs/load.mjs
+++ b/upm/Runtime/Resources/puer-commonjs/load.mjs
@@ -35,24 +35,7 @@ function searchModuleInDirWithExt(dir, requiredModule) {
     }
 }
 
-// function getFileExtension(filepath) {
-//     let last = filepath.split('/').pop();
-//     let frags = last.split('.');
-//     if (frags.length > 1) {
-//         return frags.pop();
-//     }
-// }
-
 function searchModuleInDir(dir, requiredModule) {
-    // if (getFileExtension(requiredModule)) {
-    //     return searchModuleInDirWithExt(dir, requiredModule);
-    // } else {
-    //     return searchModuleInDirWithExt(dir, requiredModule + ".js")
-    //                 || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
-    //                 || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
-    //                 || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
-    // }
-
     // Stanley: Dont know how to check a path is a dir or file in puer system, 
     //          so put requireModule at last check list to ensure its result correct.
     return searchModuleInDirWithExt(dir, requiredModule + ".js")

--- a/upm/Runtime/Resources/puer-commonjs/load.mjs
+++ b/upm/Runtime/Resources/puer-commonjs/load.mjs
@@ -35,14 +35,25 @@ function searchModuleInDirWithExt(dir, requiredModule) {
     }
 }
 
+function getFileExtension(filepath) {
+    let last = filepath.split('/').pop();
+    let frags = last.split('.');
+    if (frags.length > 1) {
+        return frags.pop();
+    }
+}
+
 function searchModuleInDir(dir, requiredModule) {
-    // Stanley: Dont know how to check a path is a dir or file in puer system, 
-    //          so put requireModule at last check list to ensure its result correct.
-    return searchModuleInDirWithExt(dir, requiredModule + ".js")
-        || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
-        || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
-        || searchModuleInDirWithExt(dir, requiredModule + "/package.json")
-        || searchModuleInDirWithExt(dir, requiredModule);
+    if (getFileExtension(requiredModule)) {
+        return searchModuleInDirWithExt(dir, requiredModule)
+            || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
+            || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
+    } else {
+        return searchModuleInDirWithExt(dir, requiredModule + ".js")
+            || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
+            || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
+            || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
+    }
 }
 
 function searchModule(dir, requiredModule) {

--- a/upm/Runtime/Resources/puer-commonjs/load.mjs
+++ b/upm/Runtime/Resources/puer-commonjs/load.mjs
@@ -28,30 +28,38 @@ function searchModuleInDirWithExt(dir, requiredModule) {
     if (puer.fileExists(searchPath)) {
         return searchPath;
     }
-    
+
     searchPath = pathNormalize(dir + '/node_modules/' + requiredModule);
     if (puer.fileExists(searchPath)) {
         return searchPath;
     }
 }
 
-function getFileExtension(filepath) {
-    let last = filepath.split('/').pop();
-    let frags = last.split('.');
-    if (frags.length > 1) {
-        return frags.pop();
-    }
-}
+// function getFileExtension(filepath) {
+//     let last = filepath.split('/').pop();
+//     let frags = last.split('.');
+//     if (frags.length > 1) {
+//         return frags.pop();
+//     }
+// }
 
 function searchModuleInDir(dir, requiredModule) {
-    if (getFileExtension(requiredModule)) {
-        return searchModuleInDirWithExt(dir, requiredModule);
-    } else {
-        return searchModuleInDirWithExt(dir, requiredModule + ".js")
-                    || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
-                    || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
-                    || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
-    }
+    // if (getFileExtension(requiredModule)) {
+    //     return searchModuleInDirWithExt(dir, requiredModule);
+    // } else {
+    //     return searchModuleInDirWithExt(dir, requiredModule + ".js")
+    //                 || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
+    //                 || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
+    //                 || searchModuleInDirWithExt(dir, requiredModule + "/package.json");
+    // }
+
+    // Stanley: Dont know how to check a path is a dir or file in puer system, 
+    //          so put requireModule at last check list to ensure its result correct.
+    return searchModuleInDirWithExt(dir, requiredModule + ".js")
+        || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
+        || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
+        || searchModuleInDirWithExt(dir, requiredModule + "/package.json")
+        || searchModuleInDirWithExt(dir, requiredModule);
 }
 
 function searchModule(dir, requiredModule) {


### PR DESCRIPTION

move the simple requiredModule check to last of the filepath check list
```
function searchModuleInDir(dir, requiredModule) {
    // Stanley: Dont know how to check a path is a dir or file in puer system, 
    //          so put requireModule at last check list to ensure its result correct.
    return searchModuleInDirWithExt(dir, requiredModule + ".js")
        || searchModuleInDirWithExt(dir, requiredModule + ".cjs")
        || searchModuleInDirWithExt(dir, requiredModule + "/index.js")
        || searchModuleInDirWithExt(dir, requiredModule + "/package.json")
        || searchModuleInDirWithExt(dir, requiredModule);
}
```
remove the getFileExtension function
